### PR TITLE
feature: add /market command to show market chart

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: add curl
-        run: sudo apt-get install libcurl4-openssl-dev
-      - name: configure
+      - name: Install Dependencies
+        run: sudo apt-get update && apt-get install libcurl4-openssl-dev -y
+      - name: Apply Configure
         run: ./configure
-      - name: cmake with fetching
+      - name: Cmake With Fetching External Dependencies
         run: cmake -DUSE_EXTERNAL_DPP=OFF -DUSE_EXTERNAL_JSON=OFF
-      - name: make
+      - name: Make
         run: make

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
-        run: sudo apt-get update && apt-get install libcurl4-openssl-dev -y
+        run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev -y
       - name: Apply Configure
         run: ./configure
       - name: Cmake With Fetching External Dependencies

--- a/include/coingecko.h
+++ b/include/coingecko.h
@@ -10,5 +10,7 @@ namespace gecko {
 
 void fetch_tokens(dpp::slashcommand_t event);
 void fetch_price(dpp::slashcommand_t event);
+void fetch_market_chart(dpp::slashcommand_t event);
+size_t write_callback(char* ptr, size_t size, size_t nmemb, std::string* data);
 
 }  // namespace gecko

--- a/include/coingecko.h
+++ b/include/coingecko.h
@@ -1,13 +1,14 @@
-#include <iostream>
-
 #include <curl/curl.h>
+#include <dpp/dpp.h>
 
 #include <cstdlib>
+#include <iostream>
 
 #include "nlohmann/json.hpp"
 
-#include <dpp/dpp.h>
-
 namespace gecko {
-void fetch(dpp::slashcommand_t event);
-}
+
+void fetch_tokens(dpp::slashcommand_t event);
+void fetch_price(dpp::slashcommand_t event);
+
+}  // namespace gecko

--- a/include/quickchart.h
+++ b/include/quickchart.h
@@ -1,0 +1,14 @@
+#include <curl/curl.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+namespace qchart {
+
+std::string generate_chart(std::string label1, std::vector<long> data1,
+                           std::string label2, std::vector<long> data2);
+size_t write_callback(char* ptr, size_t size, size_t nmemb, std::string* data);
+}  // namespace qchart

--- a/src/coingecko.cpp
+++ b/src/coingecko.cpp
@@ -92,8 +92,9 @@ void gecko::fetch_tokens(dpp::slashcommand_t event) {
     std::cout << ">> coingecko response: " << response_json << std::endl;
     std::string tokens;
     for (auto& token : response_json) {
-      tokens.append(to_string(token["id"]));
-      tokens.append(" ");
+      tokens.append("- ");
+      tokens.append(token["id"]);
+      tokens.append("\n");
     }
 
     event.reply(tokens);

--- a/src/coingecko.cpp
+++ b/src/coingecko.cpp
@@ -9,7 +9,7 @@ size_t write_callback(char* ptr, size_t size, size_t nmemb, std::string* data) {
   return size * nmemb;
 }
 
-void gecko::fetch(dpp::slashcommand_t event) {
+void gecko::fetch_price(dpp::slashcommand_t event) {
   // Get the coingecko id symbol from the command arguments.
   std::string coingecko_id =
       std::get<std::string>(event.get_parameter("coingecko_id"));
@@ -59,6 +59,51 @@ void gecko::fetch(dpp::slashcommand_t event) {
     // Reply to Discord
     event.reply(coingecko_id +
                 ":exclamation: price: error failed to call API data.");
+  }
+
+  curl_easy_cleanup(curl);
+}
+
+void gecko::fetch_tokens(dpp::slashcommand_t event) {
+  CURL* curl = curl_easy_init();
+  if (!curl) {
+    std::cerr << "Error: could not initialize libcurl" << std::endl;
+    return;
+  }
+
+  std::string url = "https://api.coingecko.com/api/v3/coins/";
+  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+
+  std::string response_data;
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_data);
+
+  CURLcode res = curl_easy_perform(curl);
+  if (res != CURLE_OK) {
+    std::cerr << "Error: curl_easy_perform() failed: "
+              << curl_easy_strerror(res) << std::endl;
+    curl_easy_cleanup(curl);
+    return;
+  }
+
+  try {
+    json response_json = json::parse(response_data);
+    std::cout << "=============================" << std::endl;
+    std::cout << ">> coingecko response: " << response_json << std::endl;
+    std::string tokens;
+    for (auto& token : response_json) {
+      tokens.append(to_string(token["id"]));
+      tokens.append(" ");
+    }
+
+    event.reply(tokens);
+
+  } catch (const std::exception& e) {
+    std::cerr << "Error: failed to parse JSON response: " << e.what()
+              << std::endl;
+    curl_easy_cleanup(curl);
+
+    event.reply(":exclamation: coins: error failed to call API data.");
   }
 
   curl_easy_cleanup(curl);

--- a/src/coingecko.cpp
+++ b/src/coingecko.cpp
@@ -1,10 +1,12 @@
 #include <coingecko.h>
+#include <quickchart.h>
 
 using json = nlohmann::json;
 
 // This callback function is called by curl_easy_perform() to write the response
 // data into a string
-size_t write_callback(char* ptr, size_t size, size_t nmemb, std::string* data) {
+size_t gecko::write_callback(char* ptr, size_t size, size_t nmemb,
+                             std::string* data) {
   data->append(ptr, size * nmemb);
   return size * nmemb;
 }
@@ -98,6 +100,58 @@ void gecko::fetch_tokens(dpp::slashcommand_t event) {
     }
 
     event.reply(tokens);
+
+  } catch (const std::exception& e) {
+    std::cerr << "Error: failed to parse JSON response: " << e.what()
+              << std::endl;
+    curl_easy_cleanup(curl);
+
+    event.reply(":exclamation: coins: error failed to call API data.");
+  }
+
+  curl_easy_cleanup(curl);
+}
+
+void gecko::fetch_market_chart(dpp::slashcommand_t event) {
+  std::string token_id = std::get<std::string>(event.get_parameter("token_id"));
+  std::string currency = std::get<std::string>(event.get_parameter("currency"));
+  std::string days = std::get<std::string>(event.get_parameter("days"));
+
+  CURL* curl = curl_easy_init();
+  if (!curl) {
+    std::cerr << "Error: could not initialize libcurl" << std::endl;
+    return;
+  }
+
+  std::string url = "https://api.coingecko.com/api/v3/coins/" + token_id +
+                    "/market_chart?vs_currency=" + currency + "&days=" + days;
+  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+
+  std::string response_data;
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_data);
+
+  CURLcode res = curl_easy_perform(curl);
+  if (res != CURLE_OK) {
+    std::cerr << "Error: curl_easy_perform() failed: "
+              << curl_easy_strerror(res) << std::endl;
+    curl_easy_cleanup(curl);
+    return;
+  }
+
+  try {
+    json response_json = json::parse(response_data);
+    // std::cout << "=============================" << std::endl;
+    // std::cout << ">> coingecko response: " << response_json << std::endl;
+    std::vector<long> timestamps;
+    std::vector<long> prices;
+    for (auto& chart : response_json["market_caps"]) {
+      timestamps.push_back(chart.at(0));
+      prices.push_back(chart.at(1));
+    }
+    auto chart = qchart::generate_chart("test", timestamps, "test", prices);
+    event.reply(chart);
+    std::cout << chart << std::endl;
 
   } catch (const std::exception& e) {
     std::cerr << "Error: failed to parse JSON response: " << e.what()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,27 +5,36 @@ int main() {
   dpp::cluster bot(std::getenv("DISCORD_TOKEN"));
 
   bot.on_slashcommand([](auto event) {
-    if (event.command.get_command_name() == "ping") {
+    auto input = event.command.get_command_name();
+    if (input == "ping") {
       event.reply("Pong!");
     }
-
-    if (event.command.get_command_name() == "price") {
-      gecko::fetch(event);
+    if (input == "price") {
+      gecko::fetch_price(event);
     }
-
+    if (input == "coins") {
+      gecko::fetch_tokens(event);
+    }
     return 0;
   });
 
   bot.on_ready([&bot](auto event) {
     if (dpp::run_once<struct register_bot_commands>()) {
+      dpp::slashcommand command_coins;
+      command_coins.set_name("coins")
+          .set_description("List of available tokens from Coingecko.")
+          .set_application_id(bot.me.id);
+      bot.global_command_create(command_coins);
+
       dpp::slashcommand command_price;
       command_price.set_name("price")
-          .set_description("Get the price of a crypto token")
+          .set_description(
+              "Get the price of a crypto token. (Please use /coins to get all "
+              "listed tokens.)")
           .set_application_id(bot.me.id)
           .add_option(
               dpp::command_option(dpp::co_string, "coingecko_id",
                                   "(Coingecko) ID of the token: ", true));
-
       bot.global_command_create(command_price);
     }
   });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,9 @@ int main() {
     if (input == "coins") {
       gecko::fetch_tokens(event);
     }
+    if (input == "market") {
+      gecko::fetch_market_chart(event);
+    }
     return 0;
   });
 
@@ -36,6 +39,21 @@ int main() {
               dpp::command_option(dpp::co_string, "coingecko_id",
                                   "(Coingecko) ID of the token: ", true));
       bot.global_command_create(command_price);
+
+      dpp::slashcommand command_market;
+      command_market.set_name("market")
+          .set_description("Get market chart of a crypto token.")
+          .set_application_id(bot.me.id)
+          .add_option(
+              dpp::command_option(dpp::co_string, "token_id",
+                                  "(Coingecko) Id of the token: ", true))
+          .add_option(
+              dpp::command_option(dpp::co_string, "currency",
+                                  "(Coingecko) Currency for the price: ", true))
+          .add_option(dpp::command_option(
+              dpp::co_string, "days",
+              "(Coingecko) Duration market in days: ", true));
+      bot.global_command_create(command_market);
     }
   });
 

--- a/src/quickchart.cpp
+++ b/src/quickchart.cpp
@@ -1,0 +1,64 @@
+#include <quickchart.h>
+
+using json = nlohmann::json;
+
+// This callback function is called by curl_easy_perform() to write the response
+// data into a string
+size_t qchart::write_callback(char* ptr, size_t size, size_t nmemb,
+                              std::string* data) {
+  data->append(ptr, size * nmemb);
+  return size * nmemb;
+}
+
+std::string qchart::generate_chart(std::string label1, std::vector<long> data1,
+                                   std::string label2,
+                                   std::vector<long> data2) {
+  CURL* curl = curl_easy_init();
+  if (!curl) {
+    std::cerr << "Error: could not initialize libcurl" << std::endl;
+    return "";
+  }
+  json datasets = json::array();
+  datasets.push_back({{"label", label2}, {"data", data2}});
+  json req_body = {{"backgroundColor", "#fff"},
+                   {"width", 500},
+                   {"height", 300},
+                   {"devicePixelRatio", 1.0},
+                   {"chart",
+                    {{"type", "bar"},
+                     {"data", {{"labels", data1}, {"datasets", datasets}}}}}};
+  std::cout << to_string(req_body).c_str() << std::endl;
+  std::string url = "https://quickchart.io/chart/create";
+  struct curl_slist* slist1 = NULL;
+  slist1 = curl_slist_append(slist1, "Content-Type: application/json");
+  slist1 = curl_slist_append(slist1, "Accept: application/json");
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist1);
+  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(curl, CURLOPT_POSTFIELDS, to_string(req_body).c_str());
+  std::string response_data;
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_data);
+
+  CURLcode res = curl_easy_perform(curl);
+  if (res != CURLE_OK) {
+    std::cerr << "Error: curl_easy_perform() failed: "
+              << curl_easy_strerror(res) << std::endl;
+    curl_easy_cleanup(curl);
+    return "";
+  }
+
+  try {
+    json response_json = json::parse(response_data);
+    std::cout << "=============================" << std::endl;
+    std::cout << ">> quickchart response: " << response_json << std::endl;
+    return response_json["url"];
+  } catch (const std::exception& e) {
+    std::cerr << "Error: failed to parse JSON response: " << e.what()
+              << std::endl;
+    curl_easy_cleanup(curl);
+    return "";
+  }
+
+  curl_easy_cleanup(curl);
+  return "";
+}


### PR DESCRIPTION
The idea is to show the specific token / coin market chart based on currency and days input from command.
Currently using [Quickchart](https://quickchart.io/documentation/) endpoints to achieve this, event tho the response still getting wrong result (Getting success response but not showing chart, PFA).
### SS Bot
![image](https://github.com/asiantbd/crypto-prices-slash-bot-cpp/assets/24561396/d15bf982-87f8-4dd4-b9b7-01ef52394332)
### SS Result
![image](https://github.com/asiantbd/crypto-prices-slash-bot-cpp/assets/24561396/e49dc304-975b-4619-a31f-fab17efb40d4)
