### PR TITLE
feat: Add support for fetching crypto prices using ticker symbol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,12 @@ option(USE_EXTERNAL_DPP "Use an external DPP library" ON)
 option(USE_EXTERNAL_JSON "Use an external JSON library" ON)
 
 if(USE_EXTERNAL_DPP)
-  find_package(dpp 10.0.23 REQUIRED)
+  find_package(dpp 10.1.0 REQUIRED)
 else()
   FetchContent_Declare(
     dpp
     GIT_REPOSITORY https://github.com/brainboxdotcc/DPP.git
-    GIT_TAG        v10.0.23
+    GIT_TAG        v10.1.0
   )
   FetchContent_MakeAvailable(dpp)
 endif()
@@ -64,3 +64,6 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 
 #Set Linker flags
 set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
+
+# Generate compile_commands.json automatically for clangd
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir build
 
 # Build the project
 WORKDIR /app/build
-RUN wget -O libdpp.deb https://github.com/brainboxdotcc/DPP/releases/download/v10.0.23/libdpp-10.0.23-linux-x64.deb \
+RUN wget -O libdpp.deb https://github.com/brainboxdotcc/DPP/releases/download/v10.1.0/libdpp-10.1.0-linux-x64.deb \
     && dpkg -i libdpp.deb \
     && ldconfig
 RUN cmake -DUSE_EXTERNAL_JSON=OFF .. -B./ && make

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker compose -f docker-compose.yml up
 ### Build
 
 #### Build Using External Precompiled Dependency (Recommended)
-- Install Precompiled Lib (Debian, Ubuntu, Derivatives), check [this link](https://dpp.dev/10.0.23/md_docpages_01_installing.html) for other distro.
+- Install Precompiled Lib (Debian, Ubuntu, Derivatives), check [this link](https://dpp.dev/installing.html) for other distro.
 
   DPP:
   ```
@@ -63,6 +63,19 @@ docker compose -f docker-compose.yml up
   cmake -DUSE_EXTERNAL_DPP=OFF -DUSE_EXTERNAL_JSON=OFF .. -B./
   make
   ```
+
+### Available Commands
+
+The bot supports the following slash commands:
+
+#### Price Query
+Get cryptocurrency prices in USD and IDR:
+- Using CoinGecko ID: `/price coingecko_id:bitcoin`
+- Using ticker symbol: `/price ticker:btc` or `/price ticker:$BTC`
+
+Note: When multiple coins share the same ticker (e.g., "ETH" for both Ethereum and Ethereum Classic),
+a dropdown menu will appear allowing you to select the specific coin.
+
 
 ### Additional
 - In case you're got error while trying `make` that caused by `curl` try install it first. ex: `sudo apt-get install libcurl4-openssl-dev`

--- a/include/coingecko.h
+++ b/include/coingecko.h
@@ -7,10 +7,9 @@
 #include "nlohmann/json.hpp"
 
 namespace gecko {
-
-void fetch_tokens(dpp::slashcommand_t event);
-void fetch_price(dpp::slashcommand_t event);
-void fetch_market_chart(dpp::slashcommand_t event);
-size_t write_callback(char* ptr, size_t size, size_t nmemb, std::string* data);
-
+    void fetch_tokens(dpp::slashcommand_t event);
+    void fetch_price(dpp::slashcommand_t event);
+    void fetch_single_price(const std::string& coingecko_id, const dpp::interaction_create_t& event);
+    void fetch_market_chart(dpp::slashcommand_t event);
+    size_t write_callback(char* ptr, size_t size, size_t nmemb, std::string* data);
 }  // namespace gecko

--- a/src/coingecko.cpp
+++ b/src/coingecko.cpp
@@ -41,88 +41,273 @@ size_t gecko::write_callback(char* ptr, size_t size, size_t nmemb,
 }
 
 void gecko::fetch_price(dpp::slashcommand_t event) {
-  // Get the coingecko id symbol from the command arguments.
-  std::string coingecko_id =
-      std::get<std::string>(event.get_parameter("coingecko_id"));
+    bool has_id = event.get_parameter("coingecko_id").index() != 0;
+    bool has_ticker = event.get_parameter("ticker").index() != 0;
 
-  CURL* curl = curl_easy_init();
-  if (!curl) {
-    std::cerr << "Error: could not initialize libcurl" << std::endl;
-    return;
-  }
-
-  // Set the URL of the API to request
-  std::string url =
-      "https://api.coingecko.com/api/v3/simple/price?ids=" + coingecko_id +
-      "&vs_currencies=usd%2Cidr";
-  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-
-  // Set the callback function to handle the response data
-  std::string response_data;
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
-  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_data);
-
-  // Perform the API request
-  CURLcode res = curl_easy_perform(curl);
-  if (res != CURLE_OK) {
-    std::cerr << "Error: curl_easy_perform() failed: "
-              << curl_easy_strerror(res) << std::endl;
-    curl_easy_cleanup(curl);
-    return;
-  }
-
-  // Parse the JSON response
-  json response_json;
-  try {
-    response_json = json::parse(response_data);
     std::cout << "=============================" << std::endl;
-    std::cout << ">> coingecko response: " << response_json << std::endl;
+    std::cout << ">> fetch_price called with:" << std::endl;
+    std::cout << "has_id: " << has_id << std::endl;
+    std::cout << "has_ticker: " << has_ticker << std::endl;
 
-  } catch (const std::exception& e) {
-    std::cerr << "Error: failed to parse JSON response: " << e.what()
-              << std::endl;
+    if (!has_id && !has_ticker) {
+        event.reply(":exclamation: Please provide either coingecko_id or ticker");
+        return;
+    }
+
+    if (has_ticker) {
+        std::string ticker = std::get<std::string>(event.get_parameter("ticker"));
+
+        // Strip $ if it exists at the beginning
+        if (!ticker.empty() && ticker[0] == '$') {
+            ticker = ticker.substr(1);
+            std::cout << ">> stripped $ from ticker: " << ticker << std::endl;
+        }
+
+        // Convert ticker to lowercase
+        std::transform(ticker.begin(), ticker.end(), ticker.begin(), ::tolower);
+        std::cout << ">> fetching by ticker (lowercase): " << ticker << std::endl;
+
+        CURL* list_curl = curl_easy_init();
+        if (!list_curl) {
+            std::cerr << "Error: could not initialize libcurl" << std::endl;
+            return;
+        }
+
+        std::string list_url = "https://api.coingecko.com/api/v3/coins/list";
+        std::string list_response;
+
+        curl_easy_setopt(list_curl, CURLOPT_URL, list_url.c_str());
+        curl_easy_setopt(list_curl, CURLOPT_WRITEFUNCTION, write_callback);
+        curl_easy_setopt(list_curl, CURLOPT_WRITEDATA, &list_response);
+
+        CURLcode list_res = curl_easy_perform(list_curl);
+        if (list_res != CURLE_OK) {
+            std::cerr << "Error: curl_easy_perform() failed: "
+                      << curl_easy_strerror(list_res) << std::endl;
+            curl_easy_cleanup(list_curl);
+            event.reply(":exclamation: Failed to fetch coin list");
+            return;
+        }
+
+        curl_easy_cleanup(list_curl);
+
+        try {
+            json coins_list = json::parse(list_response);
+            std::vector<std::pair<std::string, std::string>> matching_coins; // pairs of (id, name)
+
+            std::cout << ">> searching for matching IDs for ticker: " << ticker << std::endl;
+
+            for (const auto& coin : coins_list) {
+                // Convert coin symbol to lowercase for comparison
+                std::string coin_symbol = coin["symbol"].get<std::string>();
+                std::transform(coin_symbol.begin(), coin_symbol.end(), coin_symbol.begin(), ::tolower);
+
+                if (coin_symbol == ticker) {
+                    matching_coins.push_back({
+                        coin["id"].get<std::string>(),
+                        coin["name"].get<std::string>()
+                    });
+                }
+            }
+
+            std::cout << ">> found " << matching_coins.size() << " matching IDs" << std::endl;
+
+            if (matching_coins.empty()) {
+                event.reply(":exclamation: No coins found with ticker: " + ticker);
+                return;
+            }
+
+            if (matching_coins.size() == 1) {
+                // If only one match, fetch price directly
+                const dpp::interaction_create_t& interaction_event = event;
+                fetch_single_price(matching_coins[0].first, interaction_event);
+            } else {
+                // Create a select menu for multiple matches
+                dpp::message msg(event.command.channel_id, "Multiple coins found with ticker " + ticker + ". Please select one:");
+
+                // Create select menu
+                dpp::component select_menu;
+                select_menu.type = dpp::cot_selectmenu;
+                select_menu.custom_id = "coin_select_" + ticker;
+                select_menu.placeholder = "Select a coin";
+
+                // Add options to the select menu
+                for (const auto& coin : matching_coins) {
+                    dpp::select_option option;
+                    option.label = coin.second;         // Display name
+                    option.value = coin.first;          // CoinGecko ID
+                    option.description = "CoinGecko ID: " + coin.first;
+                    select_menu.options.push_back(option);
+                }
+
+                // Create action row
+                dpp::component action_row;
+                action_row.type = dpp::cot_action_row;
+                action_row.components.push_back(select_menu);
+
+                // Add the action row to the message
+                msg.components.push_back(action_row);
+
+                // Reply with the selection menu
+                event.reply(msg);
+            }
+
+        } catch (const std::exception& e) {
+            std::cerr << "Error parsing coin list: " << e.what() << std::endl;
+            event.reply(":exclamation: Error processing coin list");
+            return;
+        }
+    } else {
+        std::string coingecko_id = std::get<std::string>(event.get_parameter("coingecko_id"));
+        std::cout << ">> fetching by coingecko_id: " << coingecko_id << std::endl;
+        fetch_single_price(coingecko_id, event);
+    }
+}
+
+void gecko::fetch_single_price(const std::string& coingecko_id, const dpp::interaction_create_t& event) {
+    std::cout << "=============================" << std::endl;
+    std::cout << ">> fetch_single_price called for: " << coingecko_id << std::endl;
+
+    // Acknowledge the interaction first
+    event.thinking();
+
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        std::cerr << "Error: could not initialize libcurl" << std::endl;
+        return;
+    }
+
+    std::string url = "https://api.coingecko.com/api/v3/simple/price?ids=" +
+                      coingecko_id + "&vs_currencies=usd%2Cidr";
+
+    std::cout << ">> requesting URL: " << url << std::endl;
+
+    std::string response_data;
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_data);
+
+    CURLcode res = curl_easy_perform(curl);
+    if (res != CURLE_OK) {
+        std::cerr << "Error: curl_easy_perform() failed: "
+                  << curl_easy_strerror(res) << std::endl;
+        curl_easy_cleanup(curl);
+        event.reply(":exclamation: Failed to fetch price data for " + coingecko_id);
+        return;
+    }
+
+    try {
+        json response_json = json::parse(response_data);
+        std::cout << ">> coingecko response: " << response_json << std::endl;
+
+        // Check if the response contains error status
+        if (response_json.contains("status") && response_json["status"].contains("error_code")) {
+            if (response_json["status"]["error_code"] == 429) {
+                event.edit_original_response(dpp::message(":exclamation: Rate limit exceeded. Please try again later."));
+                curl_easy_cleanup(curl);
+                return;
+            }
+            std::stringstream error_msg;
+            error_msg << ":exclamation: Error fetching price data for " << coingecko_id
+                     << " , (" << response_json["status"]["error_code"].get<int>()
+                     << ") " << response_json["status"]["error_message"].get<std::string>();
+            event.edit_original_response(dpp::message(error_msg.str()));
+            curl_easy_cleanup(curl);
+            return;
+        }
+
+        // Check if the response contains data for the requested coin
+        if (response_json.empty() || !response_json.contains(coingecko_id)) {
+            event.edit_original_response(dpp::message(":exclamation: No price data found for " + coingecko_id));
+            curl_easy_cleanup(curl);
+            return;
+        }
+
+        // Check if the coin data contains both USD and IDR prices
+        if (!response_json[coingecko_id].contains("usd") ||
+            !response_json[coingecko_id].contains("idr")) {
+            event.edit_original_response(dpp::message(":exclamation: Incomplete price data for " + coingecko_id));
+            curl_easy_cleanup(curl);
+            return;
+        }
+
+        // Safely extract price values
+        std::string usd_value_str;
+        std::string idr_value_str;
+
+        // Handle different numeric types in the JSON
+        if (response_json[coingecko_id]["usd"].is_number()) {
+            usd_value_str = response_json[coingecko_id]["usd"].dump();
+            std::cout << ">> USD value string: " << usd_value_str << std::endl;
+        } else {
+            event.edit_original_response(dpp::message(":exclamation: Invalid USD price format for " + coingecko_id));
+            curl_easy_cleanup(curl);
+            return;
+        }
+
+        if (response_json[coingecko_id]["idr"].is_number()) {
+            idr_value_str = response_json[coingecko_id]["idr"].dump();
+            std::cout << ">> IDR value string: " << idr_value_str << std::endl;
+        } else {
+            event.edit_original_response(dpp::message(":exclamation: Invalid IDR price format for " + coingecko_id));
+            curl_easy_cleanup(curl);
+            return;
+        }
+
+        // Remove any quotes that might be present in the string
+        usd_value_str.erase(remove(usd_value_str.begin(), usd_value_str.end(), '"'), usd_value_str.end());
+        idr_value_str.erase(remove(idr_value_str.begin(), idr_value_str.end(), '"'), idr_value_str.end());
+
+        // Safe conversion to double with error checking
+        double usd_value, idr_value;
+        try {
+            size_t usd_pos, idr_pos;
+            usd_value = std::stod(usd_value_str, &usd_pos);
+            idr_value = std::stod(idr_value_str, &idr_pos);
+
+            std::cout << ">> Converted USD value: " << usd_value << std::endl;
+            std::cout << ">> Converted IDR value: " << idr_value << std::endl;
+
+            if (usd_pos != usd_value_str.length() || idr_pos != idr_value_str.length()) {
+                throw std::invalid_argument("Invalid number format");
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Error converting price values: " << e.what() << std::endl;
+            event.edit_original_response(dpp::message(":exclamation: Invalid price format for " + coingecko_id));
+            curl_easy_cleanup(curl);
+            return;
+        }
+
+        // Format the values
+        std::stringstream ss_usd;
+        ss_usd.imbue(get_locale("en_US.UTF-8"));
+        ss_usd << std::fixed
+               << std::setprecision(determine_precision_from_str(usd_value_str))
+               << usd_value;
+
+        std::stringstream ss_idr;
+        ss_idr.imbue(get_locale("id_ID.UTF-8"));
+        ss_idr << std::fixed
+               << std::setprecision(determine_precision_from_str(idr_value_str))
+               << idr_value;
+
+        std::cout << ">> Formatted USD: " << ss_usd.str() << std::endl;
+        std::cout << ">> Formatted IDR: " << ss_idr.str() << std::endl;
+
+        // Reply with formatted price
+        event.edit_original_response(dpp::message(":information_source: " + coingecko_id +
+                   " price: $" + ss_usd.str() +
+                   " / Rp." + ss_idr.str()));
+
+    } catch (const json::parse_error& e) {
+        std::cerr << "JSON parsing error: " << e.what() << std::endl;
+        event.edit_original_response(dpp::message(":exclamation: Failed to parse price data for " + coingecko_id));
+    } catch (const std::exception& e) {
+        std::cerr << "Error processing price data: " << e.what() << std::endl;
+        event.edit_original_response(dpp::message(":exclamation: Error processing price data for " + coingecko_id));
+    }
+
     curl_easy_cleanup(curl);
-
-    // Reply to Discord
-    event.reply(coingecko_id +
-                ":exclamation: price: error failed to call API data.");
-  }
-
-  // Format response value
-  try {
-    // Use std::string to determine precision point
-    // without converting to <double> first -- converting may have default precision point.
-    std::string usd_value_str = to_string(response_json[coingecko_id]["usd"]);
-    std::string idr_value_str = to_string(response_json[coingecko_id]["idr"]);
-
-    // Format USD
-    std::stringstream ss_usd;
-    ss_usd.imbue(get_locale("en_US.UTF-8"));
-    ss_usd << std::fixed << std::setprecision(determine_precision_from_str(usd_value_str))
-            << std::stod(usd_value_str);
-
-    // Format IDR
-    std::stringstream ss_idr;
-    ss_idr.imbue(get_locale("id_ID.UTF-8"));
-    ss_idr << std::fixed << std::setprecision(determine_precision_from_str(idr_value_str))
-            << std::stod(idr_value_str);
-
-    // Reply to Discord
-    event.reply(":information_source: " + coingecko_id +
-                " price: $" +  ss_usd.str() +
-                " / Rp." + ss_idr.str());
-
-  } catch (const std::exception& e) {
-    std::cerr << "Error: failed to parse currency value: " << e.what()
-            << std::endl;
-    curl_easy_cleanup(curl);
-
-    // Reply to Discord
-    event.reply(coingecko_id +
-                ":exclamation: price: formatting error.");
-  }
-
-  curl_easy_cleanup(curl);
 }
 
 void gecko::fetch_tokens(dpp::slashcommand_t event) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,59 +2,89 @@
 #include <dpp/dpp.h>
 
 int main() {
-  dpp::cluster bot(std::getenv("DISCORD_TOKEN"));
+    // For slash commands and components, we only need default intents
+    dpp::cluster bot(std::getenv("DISCORD_TOKEN"), dpp::i_default_intents);
 
-  bot.on_slashcommand([](auto event) {
-    auto input = event.command.get_command_name();
-    if (input == "ping") {
-      event.reply("Pong!");
-    }
-    if (input == "price") {
-      gecko::fetch_price(event);
-    }
-    if (input == "coins") {
-      gecko::fetch_tokens(event);
-    }
-    if (input == "market") {
-      gecko::fetch_market_chart(event);
-    }
+    bot.on_slashcommand([](const dpp::slashcommand_t& event) {
+        std::cout << "Received slash command: " << event.command.get_command_name() << std::endl;
+
+        auto input = event.command.get_command_name();
+        if (input == "ping") {
+            event.reply("Pong!");
+        }
+        if (input == "price") {
+            gecko::fetch_price(event);
+        }
+        if (input == "coins") {
+            gecko::fetch_tokens(event);
+        }
+        if (input == "market") {
+            gecko::fetch_market_chart(event);
+        }
+    });
+
+    // Add select menu handler
+    bot.on_select_click([](const dpp::select_click_t& event) {
+        std::cout << "Received select menu interaction with custom_id: " << event.custom_id << std::endl;
+
+        if (event.custom_id.find("coin_select_") == 0) {
+            std::cout << "Processing coin selection..." << std::endl;
+            std::string selected_id = event.values[0];
+            std::cout << "Selected coin ID: " << selected_id << std::endl;
+
+            // Then fetch and send the price
+            try {
+                gecko::fetch_single_price(selected_id, event);
+            } catch (const std::exception& e) {
+                std::cerr << "Error in select menu handler: " << e.what() << std::endl;
+                event.edit_response(":exclamation: Error processing selection");
+            }
+        }
+    });
+
+    bot.on_ready([&bot](const dpp::ready_t& event) {
+        std::cout << "Bot is ready!" << std::endl;
+        if (dpp::run_once<struct register_bot_commands>()) {
+            std::cout << "Registering commands..." << std::endl;
+
+            dpp::slashcommand command_coins;
+            command_coins.set_name("coins")
+                .set_description("List of available tokens from Coingecko.")
+                .set_application_id(bot.me.id);
+            bot.global_command_create(command_coins);
+
+            dpp::slashcommand command_price;
+            command_price.set_name("price")
+                .set_description(
+                    "Get the price of a crypto token using ID or ticker symbol")
+                .set_application_id(bot.me.id)
+                .add_option(
+                    dpp::command_option(dpp::co_string, "ticker",
+                                      "Ticker ($) symbol of the token", false))
+                .add_option(
+                    dpp::command_option(dpp::co_string, "coingecko_id",
+                                      "Coingecko ID of the token", false));
+
+            bot.global_command_create(command_price);
+
+            dpp::slashcommand command_market;
+            command_market.set_name("market")
+                .set_description(
+                    "Get market chart of a crypto token (1 day interval).")
+                .set_application_id(bot.me.id)
+                .add_option(
+                    dpp::command_option(dpp::co_string, "token_id",
+                                      "(Coingecko) Id of the token: ", true))
+                .add_option(
+                    dpp::command_option(dpp::co_string, "currency",
+                                      "(Coingecko) Currency for the price: ", true));
+            bot.global_command_create(command_market);
+
+            std::cout << "Commands registered successfully!" << std::endl;
+        }
+    });
+
+    std::cout << "Starting bot..." << std::endl;
+    bot.start(dpp::st_wait);
     return 0;
-  });
-
-  bot.on_ready([&bot](auto event) {
-    if (dpp::run_once<struct register_bot_commands>()) {
-      dpp::slashcommand command_coins;
-      command_coins.set_name("coins")
-          .set_description("List of available tokens from Coingecko.")
-          .set_application_id(bot.me.id);
-      bot.global_command_create(command_coins);
-
-      dpp::slashcommand command_price;
-      command_price.set_name("price")
-          .set_description(
-              "Get the price of a crypto token. (Please use /coins to get all "
-              "listed tokens.)")
-          .set_application_id(bot.me.id)
-          .add_option(
-              dpp::command_option(dpp::co_string, "coingecko_id",
-                                  "(Coingecko) ID of the token: ", true));
-      bot.global_command_create(command_price);
-
-      dpp::slashcommand command_market;
-      command_market.set_name("market")
-          .set_description(
-              "Get market chart of a crypto token (1 day interval).")
-          .set_application_id(bot.me.id)
-          .add_option(
-              dpp::command_option(dpp::co_string, "token_id",
-                                  "(Coingecko) Id of the token: ", true))
-          .add_option(dpp::command_option(
-              dpp::co_string, "currency",
-              "(Coingecko) Currency for the price: ", true));
-      bot.global_command_create(command_market);
-    }
-  });
-
-  bot.start(dpp::st_wait);
-  return 0;
 }


### PR DESCRIPTION
## Changes

- New option to fetch crypto prices using ticker symbol (e.g., "BTC", "ETH")
- Interactive dropdown menu for selecting specific coin when multiple matches are found for a ticker
- Handling minor cases (case-insensitive, $ prefix, CoinGecko rate-limit error)

### Example Usage
Users can now fetch prices in two ways:
- Using CoinGecko ID: `/price coingecko_id:bitcoin`
- Using ticker symbol: `/price ticker:btc` or `/price ticker:$BTC`

When multiple coins share the same ticker (e.g., "ETH" for both Ethereum and specific chain Ethereum Wrapped token), 
a dropdown menu will appear allowing users to select the specific coin they want.